### PR TITLE
Fix link attributes and add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # kevins-homepage
-personal site, ok?
+This repository contains the static files for Kevin Keyes's personal contact site, which is hosted at https://k-keyes.github.io/.

--- a/index.html
+++ b/index.html
@@ -56,6 +56,7 @@
             aria-label="external link to my linkedin profile"
             class="link-anchor"
             target="_blank"
+            rel="noopener noreferrer"
             href="https://www.linkedin.com/in/kevinforrestkeyes/"
           >
             <svg
@@ -79,6 +80,7 @@
             aria-label="external link to my github profile"
             class="link-anchor"
             target="_blank"
+            rel="noopener noreferrer"
             href="https://github.com/k-keyes"
           >
             <svg
@@ -102,6 +104,7 @@
             aria-label="external link to my instagram profile"
             class="link-anchor"
             target="_blank"
+            rel="noopener noreferrer"
             href="https://www.instagram.com/kevd00g/"
           >
             <svg

--- a/styles.css
+++ b/styles.css
@@ -68,7 +68,7 @@ body {
   position: relative;
   display: flex;
   justify-content: center;
-  align-content: center;
+  align-items: center;
   border: 2px solid var(--fontColor);
   border-radius: 50%;
   width: 32px;

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -1,0 +1,17 @@
+import os
+import unittest
+from bs4 import BeautifulSoup
+
+
+class TestLinkRelAttributes(unittest.TestCase):
+    def test_external_links_have_rel(self):
+        with open(os.path.join(os.path.dirname(os.path.dirname(__file__)), 'index.html')) as f:
+            soup = BeautifulSoup(f, 'html.parser')
+        for a in soup.find_all('a', target='_blank'):
+            rel = (a.get('rel') or '').split()
+            self.assertIn('noopener', rel)
+            self.assertIn('noreferrer', rel)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add README text describing the website
- enforce link-rel check with unittest
- ignore Python cache files

## Testing
- `python3 -m unittest discover -s tests` *(fails: ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_6859ec5ac16c83318844a0487a8d8b12